### PR TITLE
ublox: Bug fix in resetting message buffer

### DIFF
--- a/ublox/ublox.py
+++ b/ublox/ublox.py
@@ -787,7 +787,7 @@ else:
                 '''handle corrupted streams'''
                 self._buf = self._buf[1:]
             if self.needed_bytes() < 0:
-                self._buf = ""
+                self._buf = b""
 
         def checksum(self, data=None):
             '''return a checksum tuple for a message'''


### PR DESCRIPTION
In Python3 data should be in byte type. This bug was fixed with this commit.